### PR TITLE
Settings feature

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import SubmitDesign from './pages/SubmitDesign/SubmitDesign';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
 import Profile from './pages/Profile/Profile';
+import Settings from './pages/Settings/Settings'
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
@@ -24,6 +25,7 @@ function App(): JSX.Element {
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path="/submit-design/:id" component={SubmitDesign} />
                 <Route exact path="/profile" component={Profile} />
+                <Route exact path="/settings" component={Settings} />
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Box, Typography, Tabs, Tab } from '@material-ui/core';
+import useStyles from "./useStyles";
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`tabpanel-${index}`}
+      aria-labelledby={`tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box p={3}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+function tabProps(index: number) {
+  return {
+    id: `tab-${index}`,
+    'aria-controls': `tabpanel-${index}`,
+  };
+}
+
+export default function Settings(): JSX.Element {
+  const [value, setValue] = useState<number>(0);
+  const classes = useStyles();
+
+  const handleChange = (event: React.ChangeEvent<Record<string, unknown>>, val: number) => {
+    setValue(val);
+  };
+
+  return (
+    <div className={classes.root}>
+      <Tabs
+      orientation='vertical'
+      variant='fullWidth'
+      indicatorColor='primary'
+      textColor='primary'
+      value={value}
+      onChange={handleChange}
+      classes={{indicator: classes.indicator}}
+      className={classes.tabs}>
+        <Tab label='Profile' {...tabProps(0)} className={classes.tab} />
+        <Tab label='Personal Information' {...tabProps(1)} className={classes.tab} />
+        <Tab label='Payment Details' {...tabProps(2)} className={classes.tab} />
+        <Tab label='Notification' {...tabProps(3)} className={classes.tab} />
+        <Tab label='Password' {...tabProps(4)} className={classes.tab} />
+      </Tabs>
+      <TabPanel value={value} index={0}>
+        Profile
+      </TabPanel>
+      <TabPanel value={value} index={1}>
+        Personal Information
+      </TabPanel>
+      <TabPanel value={value} index={2}>
+        Payment Details
+      </TabPanel>
+      <TabPanel value={value} index={3}>
+        Notification
+      </TabPanel>
+      <TabPanel value={value} index={4}>
+        Password
+      </TabPanel>
+    </div>
+  );
+};

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -44,21 +44,28 @@ export default function Settings(): JSX.Element {
   };
 
   return (
-    <div className={classes.root}>
+    <Box className={classes.root}>
       <Tabs
       orientation='vertical'
-      variant='fullWidth'
       indicatorColor='primary'
       textColor='primary'
       value={value}
+      TabIndicatorProps={{
+        style: {
+          height: 20,
+          marginTop: 15,
+        }
+      }}
+      classes={{
+        indicator: classes.indicator,
+      }}
       onChange={handleChange}
-      classes={{indicator: classes.indicator}}
       className={classes.tabs}>
-        <Tab label='Profile' {...tabProps(0)} className={classes.tab} />
-        <Tab label='Personal Information' {...tabProps(1)} className={classes.tab} />
-        <Tab label='Payment Details' {...tabProps(2)} className={classes.tab} />
-        <Tab label='Notification' {...tabProps(3)} className={classes.tab} />
-        <Tab label='Password' {...tabProps(4)} className={classes.tab} />
+        <Tab label='Profile' {...tabProps(0)} className={classes.label} />
+        <Tab label='Personal Information' {...tabProps(1)} className={classes.label} />
+        <Tab label='Payment Details' {...tabProps(2)} className={classes.label} />
+        <Tab label='Notification' {...tabProps(3)} className={classes.label} />
+        <Tab label='Password' {...tabProps(4)} className={classes.label} />
       </Tabs>
       <TabPanel value={value} index={0}>
         Profile
@@ -75,6 +82,6 @@ export default function Settings(): JSX.Element {
       <TabPanel value={value} index={4}>
         Password
       </TabPanel>
-    </div>
+    </Box>
   );
 };

--- a/client/src/pages/Settings/useStyles.ts
+++ b/client/src/pages/Settings/useStyles.ts
@@ -9,18 +9,22 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tabs: {
     backgroundColor: theme.palette.background.paper,
-    width: '20%',
-    marginLeft: 15,
+    width: '40vh',
+    overflow: 'hidden',
     borderRight: `1px solid ${theme.palette.divider}`,
     boxShadow: '3px 0 5px -2px #DDDDDD',
     paddingTop: 20,
+    "& .MuiTab-wrapper": {
+      flexDirection: "row",
+      justifyContent: "flex-start"
+    },
   },
-  tab: {
+  label: {
     fontSize: '14px',
+    left: '20%',
   },
   indicator: {
-    left: 0,
-    height: '1px',
+    left: '10%',
     transform: 'rotate(90deg)',
   },
 }));

--- a/client/src/pages/Settings/useStyles.ts
+++ b/client/src/pages/Settings/useStyles.ts
@@ -1,0 +1,28 @@
+import { makeStyles, Theme } from "@material-ui/core";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    display: 'flex',
+    flexGrow: 1,
+    height: '100vh',
+    overflow: 'hidden',
+  },
+  tabs: {
+    backgroundColor: theme.palette.background.paper,
+    width: '20%',
+    marginLeft: 15,
+    borderRight: `1px solid ${theme.palette.divider}`,
+    boxShadow: '3px 0 5px -2px #DDDDDD',
+    paddingTop: 20,
+  },
+  tab: {
+    fontSize: '14px',
+  },
+  indicator: {
+    left: 0,
+    height: '1px',
+    transform: 'rotate(90deg)',
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
### What this PR does (required):
- A skeleton of the settings page to allow users to switch to different views on click.

### Screenshots / Videos (required):
- ![Screen Shot 2021-07-15 at 3 13 23 PM](https://user-images.githubusercontent.com/72681019/125865678-7b780b85-2fff-4cd4-bee5-9837c4f328c1.png)

### Any information needed to test this feature (required):
- Go to /settings route and click on different tabs.

### Any issues with the current functionality (optional):
- Just a CSS problem I couldn't figure out. Aligning the tabs to the left.
