### PR TITLE
Feature/discovery page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import SubmitDesign from './pages/SubmitDesign/SubmitDesign';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
 import Profile from './pages/Profile/Profile';
+import Discovery from './pages/Discovery/Discovery';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
@@ -24,6 +25,7 @@ function App(): JSX.Element {
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path="/submit-design/:id" component={SubmitDesign} />
                 <Route exact path="/profile" component={Profile} />
+                <Route exact path="/discovery" component={Discovery} />
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>
@@ -32,7 +34,7 @@ function App(): JSX.Element {
                 </Route>
               </Switch>
             </SocketProvider>
-           </AuthProvider>
+          </AuthProvider>
         </SnackBarProvider>
       </BrowserRouter>
     </MuiThemeProvider>

--- a/client/src/components/AuthHeader/AuthHeader.tsx
+++ b/client/src/components/AuthHeader/AuthHeader.tsx
@@ -30,7 +30,7 @@ const AuthHeader = ({ linkTo, btnText }: Props): JSX.Element => {
           flexWrap="wrap"
           className={classes.linkContainer}
         >
-          <Link to="/submit-design/99">
+          <Link to="/discovery">
             <Typography className={classes.navLink} color="secondary" display="inline">
               Discover
             </Typography>

--- a/client/src/interface/Discovery.ts
+++ b/client/src/interface/Discovery.ts
@@ -1,7 +1,6 @@
 export interface Column {
-    id: 'Contest Title' | 'Contest Description' | 'Prize Amount' | 'Deadline Date';
+    id: 'Contest Title' | 'Contest Description' | 'Prize Amount' | 'Deadline Date' | 'More Info';
     label: string;
-    minWidth: number;
+    minWidth?: number;
     align?: 'right';
-    format?: (value: number) => string;
 }

--- a/client/src/interface/Discovery.ts
+++ b/client/src/interface/Discovery.ts
@@ -1,0 +1,7 @@
+export interface Column {
+    id: 'Contest Title' | 'Contest Description' | 'Prize Amount' | 'Deadline Date';
+    label: string;
+    minWidth: number;
+    align?: 'right';
+    format?: (value: number) => string;
+}

--- a/client/src/pages/Discovery/Discovery.tsx
+++ b/client/src/pages/Discovery/Discovery.tsx
@@ -83,7 +83,7 @@ export default function Discovery(): JSX.Element {
                     </Grid>
                 </Container>
                 <Paper className={classes.paper}>
-                    <TableContainer className={classes.tableContainer}>
+                    <TableContainer>
                         <Table stickyHeader aria-label="sticky table">
                             <TableHead>
                                 <TableRow className={classes.tableHead}>

--- a/client/src/pages/Discovery/Discovery.tsx
+++ b/client/src/pages/Discovery/Discovery.tsx
@@ -30,10 +30,8 @@ export default function Discovery(): JSX.Element {
         async function getAll() {
             try {
                 const allContests = await getAllContests();
-
-                if (allContests.contests) {
-                    console.log(allContests.contests)
-                    setContests(allContests.contests)
+                if (allContests) {
+                    // setContests(allContests)
                 }
             } catch (err) {
                 console.log("No Contests Found")
@@ -44,6 +42,29 @@ export default function Discovery(): JSX.Element {
         getAll()
     }, []);
 
+    const columns: Column[] = [
+        { id: 'Contest Title', label: 'Contest Title', minWidth: 50 },
+        { id: 'Contest Description', label: 'Contest Description', minWidth: 50 },
+        {
+            id: 'Prize Amount',
+            label: 'Prize Amount',
+            minWidth: 50,
+            align: 'right',
+        },
+        {
+            id: 'Deadline Date',
+            label: 'Deadline Date',
+            minWidth: 50,
+            align: 'right',
+        },
+        {
+            id: 'More Info',
+            label: 'More Info',
+            minWidth: 50,
+            align: 'right',
+        },
+    ];
+
     const handleChangePage = (event: unknown, newPage: number) => {
         setPage(newPage);
     };
@@ -53,7 +74,7 @@ export default function Discovery(): JSX.Element {
         setPage(0);
     };
 
-    return loggedInUser ? (
+    return (
         <>
             <AuthHeader linkTo="/createcontest" btnText="create contest" />
             <Grid container justify="center" className={classes.grid}>
@@ -62,14 +83,42 @@ export default function Discovery(): JSX.Element {
                         <Typography className={classes.typography}>All Contests</Typography>
                     </Grid>
                 </Container>
-            <Paper className={classes.paper}>
-                <TableContainer classname={classes.tableContainer}>
-                    
-                </TableContainer>
-            </Paper>
 
+                <Paper className={classes.paper}>
+                    <TableContainer className={classes.tableContainer}>
+                        <Table stickyHeader aria-label="sticky table">
+                            <TableHead>
+                                <TableRow className={classes.tableHead}>
+                                    <TableCell className={classes.tableRow} key={columns[0].id} align={columns[0].align} style={{ minWidth: columns[0].minWidth }}>
+                                        {columns[0].label}
+                                    </TableCell>
+                                    <TableCell className={classes.tableRow} key={columns[1].id} align={columns[1].align} style={{ minWidth: columns[1].minWidth }}>
+                                        {columns[1].label}
+                                    </TableCell>
+                                    <TableCell className={classes.tableRow} key={columns[2].id} align={columns[2].align} style={{ minWidth: columns[2].minWidth }}>
+                                        {columns[2].label}
+                                    </TableCell>
+                                    <TableCell className={classes.tableRow} key={columns[3].id} align={columns[3].align} style={{ minWidth: columns[3].minWidth }}>
+                                        {columns[3].label}
+                                    </TableCell>
+                                    <TableCell className={classes.tableRow} key={columns[4].id} align={columns[4].align} style={{ minWidth: columns[4].minWidth }}>
+                                        {columns[4].label}
+                                    </TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {contests.map(contest => {
+                                    return (
+                                        console.log(contest)
+                                    )
+                                })}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                </Paper>
             </Grid>
         </>
-    ) : (<CircularProgress />)
+    )
 
 }
+

--- a/client/src/pages/Discovery/Discovery.tsx
+++ b/client/src/pages/Discovery/Discovery.tsx
@@ -28,19 +28,18 @@ export default function Discovery(): JSX.Element {
 
     useEffect(() => {
         async function getAll() {
-            try {
-                const allContests = await getAllContests();
-                if (allContests) {
-                    // setContests(allContests)
-                }
-            } catch (err) {
+            const allContests = await getAllContests();
+            if (allContests.contests) {
+                setContests(allContests.contests)
+            } else {
                 console.log("No Contests Found")
                 new Error("Could Not Get Contests")
-            };
+            }
         };
-
         getAll()
     }, []);
+
+
 
     const columns: Column[] = [
         { id: 'Contest Title', label: 'Contest Title', minWidth: 50 },
@@ -59,7 +58,7 @@ export default function Discovery(): JSX.Element {
         },
         {
             id: 'More Info',
-            label: 'More Info',
+            label: 'Contest Page',
             minWidth: 50,
             align: 'right',
         },
@@ -78,12 +77,11 @@ export default function Discovery(): JSX.Element {
         <>
             <AuthHeader linkTo="/createcontest" btnText="create contest" />
             <Grid container justify="center" className={classes.grid}>
-                <Container>
+                <Container className={classes.tableContainer}>
                     <Grid item>
-                        <Typography className={classes.typography}>All Contests</Typography>
+                        <Typography className={classes.typography}>All Open Contests</Typography>
                     </Grid>
                 </Container>
-
                 <Paper className={classes.paper}>
                     <TableContainer className={classes.tableContainer}>
                         <Table stickyHeader aria-label="sticky table">
@@ -109,7 +107,25 @@ export default function Discovery(): JSX.Element {
                             <TableBody>
                                 {contests.map(contest => {
                                     return (
-                                        console.log(contest)
+                                        <>
+                                            <TableRow hover role="checkbox" className={classes.tableHead} tabIndex={-1} key={contest.title}>
+                                                <TableCell className={classes.tableRow}>
+                                                    {contest.title}
+                                                </TableCell>
+                                                <TableCell className={classes.tableRow}>
+                                                    {contest.description}
+                                                </TableCell>
+                                                <TableCell className={classes.tableRow}>
+                                                    {contest.prizeAmount}
+                                                </TableCell>
+                                                <TableCell className={classes.tableRow}>
+                                                    {contest.deadlineDate}
+                                                </TableCell>
+                                                <TableCell className={classes.tableRow}>
+                                                    <Button className={classes.button}>More Info</Button>
+                                                </TableCell>
+                                            </TableRow>
+                                        </>
                                     )
                                 })}
                             </TableBody>

--- a/client/src/pages/Discovery/Discovery.tsx
+++ b/client/src/pages/Discovery/Discovery.tsx
@@ -39,31 +39,6 @@ export default function Discovery(): JSX.Element {
         getAll()
     }, []);
 
-
-
-    const columns: Column[] = [
-        { id: 'Contest Title', label: 'Contest Title', minWidth: 50 },
-        { id: 'Contest Description', label: 'Contest Description', minWidth: 50 },
-        {
-            id: 'Prize Amount',
-            label: 'Prize Amount',
-            minWidth: 50,
-            align: 'right',
-        },
-        {
-            id: 'Deadline Date',
-            label: 'Deadline Date',
-            minWidth: 50,
-            align: 'right',
-        },
-        {
-            id: 'More Info',
-            label: 'Contest Page',
-            minWidth: 50,
-            align: 'right',
-        },
-    ];
-
     const handleChangePage = (event: unknown, newPage: number) => {
         setPage(newPage);
     };
@@ -75,7 +50,7 @@ export default function Discovery(): JSX.Element {
 
     return (
         <>
-            <AuthHeader linkTo="/createcontest" btnText="create contest" />
+            <AuthHeader linkTo="/create-contest" btnText="create contest" />
             <Grid container justify="center" className={classes.grid}>
                 <Container className={classes.tableContainer}>
                     <Grid item>
@@ -87,20 +62,20 @@ export default function Discovery(): JSX.Element {
                         <Table stickyHeader aria-label="sticky table">
                             <TableHead>
                                 <TableRow className={classes.tableHead}>
-                                    <TableCell className={classes.tableRow} key={columns[0].id} align={columns[0].align} style={{ minWidth: columns[0].minWidth }}>
-                                        {columns[0].label}
+                                    <TableCell className={classes.tableRow} key='Contest Title'>
+                                        Contest Title
                                     </TableCell>
-                                    <TableCell className={classes.tableRow} key={columns[1].id} align={columns[1].align} style={{ minWidth: columns[1].minWidth }}>
-                                        {columns[1].label}
+                                    <TableCell className={classes.tableRow} key='Contest Description'>
+                                        Contest Description
                                     </TableCell>
-                                    <TableCell className={classes.tableRow} key={columns[2].id} align={columns[2].align} style={{ minWidth: columns[2].minWidth }}>
-                                        {columns[2].label}
+                                    <TableCell className={classes.tableRow} key="Prize Amount">
+                                        Prize Amount
                                     </TableCell>
-                                    <TableCell className={classes.tableRow} key={columns[3].id} align={columns[3].align} style={{ minWidth: columns[3].minWidth }}>
-                                        {columns[3].label}
+                                    <TableCell className={classes.tableRow} key='Deadline Date'>
+                                        Deadline Date
                                     </TableCell>
-                                    <TableCell className={classes.tableRow} key={columns[4].id} align={columns[4].align} style={{ minWidth: columns[4].minWidth }}>
-                                        {columns[4].label}
+                                    <TableCell className={classes.tableRow} key='Contest Page'>
+                                        Contest Page
                                     </TableCell>
                                 </TableRow>
                             </TableHead>

--- a/client/src/pages/Discovery/Discovery.tsx
+++ b/client/src/pages/Discovery/Discovery.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../../context/useAuthContext';
+import { Contest } from '../../interface/User';
+import { getAllContests } from '../../helpers/APICalls/contest';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Button from '@material-ui/core/Button';
+import useStyles from './useStyles';
+
+export default function Discovery(): JSX.Element {
+    const [contests, setContests] = useState<Contest[]>([]);
+    const { loggedInUser } = useAuth();
+    const classes = useStyles();
+
+    useEffect(() => {
+        async function getAll() {
+            try {
+                const allContests = await getAllContests();
+
+                if (allContests.contests) {
+                    console.log(allContests.contests)
+                    setContests(allContests.contests)
+                }
+            } catch (err) {
+                console.log("No Contests Found")
+                new Error("Could Not Get Contests")
+            };
+        };
+
+        getAll()
+    }, []);
+
+    return loggedInUser ? (
+        <>
+
+        </>
+    ) : (<CircularProgress />)
+
+}

--- a/client/src/pages/Discovery/Discovery.tsx
+++ b/client/src/pages/Discovery/Discovery.tsx
@@ -1,15 +1,28 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../../context/useAuthContext';
 import { Contest } from '../../interface/User';
+import { Column } from '../../interface/Discovery';
 import { getAllContests } from '../../helpers/APICalls/contest';
+import AuthHeader from '../../components/AuthHeader/AuthHeader';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import Container from '@material-ui/core/Container';
 import Button from '@material-ui/core/Button';
+import Paper from '@material-ui/core/Paper';
+import TableContainer from '@material-ui/core/TableContainer';
+import Table from '@material-ui/core/Table';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+import TableBody from '@material-ui/core/TableBody';
+import TablePagination from '@material-ui/core/TablePagination';
 import useStyles from './useStyles';
 
 export default function Discovery(): JSX.Element {
     const [contests, setContests] = useState<Contest[]>([]);
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(10)
     const { loggedInUser } = useAuth();
     const classes = useStyles();
 
@@ -31,9 +44,31 @@ export default function Discovery(): JSX.Element {
         getAll()
     }, []);
 
+    const handleChangePage = (event: unknown, newPage: number) => {
+        setPage(newPage);
+    };
+
+    const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setRowsPerPage(+event.target.value);
+        setPage(0);
+    };
+
     return loggedInUser ? (
         <>
+            <AuthHeader linkTo="/createcontest" btnText="create contest" />
+            <Grid container justify="center" className={classes.grid}>
+                <Container>
+                    <Grid item>
+                        <Typography className={classes.typography}>All Contests</Typography>
+                    </Grid>
+                </Container>
+            <Paper className={classes.paper}>
+                <TableContainer classname={classes.tableContainer}>
+                    
+                </TableContainer>
+            </Paper>
 
+            </Grid>
         </>
     ) : (<CircularProgress />)
 

--- a/client/src/pages/Discovery/useStyles.ts
+++ b/client/src/pages/Discovery/useStyles.ts
@@ -25,7 +25,8 @@ const useStyles = makeStyles(() => ({
     },
     tableRow: {
         padding: '25px 0px 25px 0px',
-        textAlign: 'center'
+        textAlign: 'center',
+        minWidth: 50
     },
     button: {
         fontWeight: 'bold',

--- a/client/src/pages/Discovery/useStyles.ts
+++ b/client/src/pages/Discovery/useStyles.ts
@@ -17,13 +17,22 @@ const useStyles = makeStyles(() => ({
         width: '50%'
     },
     tableContainer: {
-        
+        marginBottom: '50px',
+        marginTop: '50px'
     },
     tableHead: {
         width: '100%'
     },
     tableRow: {
-        padding: '25px'
+        padding: '25px 0px 25px 0px',
+        textAlign: 'center'
+    },
+    button: {
+        fontWeight: 'bold',
+        backgroundColor: 'black',
+        color: 'white',
+        padding: '4px 8px',
+        marginLeft: '10px'
     }
 }))
 

--- a/client/src/pages/Discovery/useStyles.ts
+++ b/client/src/pages/Discovery/useStyles.ts
@@ -14,10 +14,16 @@ const useStyles = makeStyles(() => ({
         textAlign: 'center'
     },
     paper: {
-        width: '100%'
+        width: '50%'
     },
     tableContainer: {
-        maxWidth: '440px'
+        
+    },
+    tableHead: {
+        width: '100%'
+    },
+    tableRow: {
+        padding: '25px'
     }
 }))
 

--- a/client/src/pages/Discovery/useStyles.ts
+++ b/client/src/pages/Discovery/useStyles.ts
@@ -1,7 +1,24 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
-
+    grid: {
+        height: '100%',
+        width: '100%'
+    },
+    typography: {
+        fontSize: '50px',
+        fontWeight: 'bold',
+        borderBottom: '2px #DCDCDC',
+        borderBottomWidth: '2px',
+        borderBottomStyle: 'solid',
+        textAlign: 'center'
+    },
+    paper: {
+        width: '100%'
+    },
+    tableContainer: {
+        maxWidth: '440px'
+    }
 }))
 
 export default useStyles;

--- a/client/src/pages/Discovery/useStyles.ts
+++ b/client/src/pages/Discovery/useStyles.ts
@@ -1,0 +1,7 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+
+}))
+
+export default useStyles;

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -106,7 +106,7 @@ export default function Profile(): JSX.Element {
 
     return loggedInUser ? (
         <>
-            <AuthHeader linkTo="/signup" btnText="sign up" />
+            <AuthHeader linkTo="/createcontest" btnText="create contest" />
             <Grid className={classes.grid} container alignItems="center" direction="column">
                 <Avatar alt="Profile Image" src={ProfilePic} className={classes.avatar}></Avatar>
                 <Typography className={classes.user}>{loggedInUser.username}</Typography>

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -46,16 +46,13 @@ export default function Profile(): JSX.Element {
 
     useEffect(() => {
         async function getUserContests() {
-            try {
-                const userContests = await getContestByUser();
-                if (userContests.contests) {
-                    setContests(userContests.contests);
-                }
-            } catch (err) {
+            const userContests = await getContestByUser();
+            if (userContests.contests) {
+                setContests(userContests.contests);
+            } else {
                 new Error("Could Not Get Contests")
             }
         }
-
         getUserContests();
     }, []);
 

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -52,7 +52,7 @@ export default function Profile(): JSX.Element {
                     setContests(userContests.contests);
                 }
             } catch (err) {
-                console.log(err)
+                new Error("Could Not Get Contests")
             }
         }
 

--- a/server/app.js
+++ b/server/app.js
@@ -26,7 +26,7 @@ const io = socketio(server, {
 });
 
 io.on("connection", (socket) => {
-  console.log("connected", socket);
+  console.log("connected");
 });
 
 if (process.env.NODE_ENV === "development") {

--- a/server/controllers/contest.js
+++ b/server/controllers/contest.js
@@ -45,7 +45,9 @@ exports.getAllContests = asyncHandler(async (req, res) => {
     try {
         const allContests = await Contest.find({})
 
-        res.status(200).json(allContests)
+        res.status(200).json({
+            contests: allContests
+        })
     } catch (err) {
         res.status(500).json(err);
     }


### PR DESCRIPTION
### What this PR does (required):
- Initial discovery page done, page is getting the data for all of the contests and that data is being displayed in a MaterialUI table. I need to still convert the date from UTC format as well as Pagination. Pagination may be a nice to have.

### Screenshots / Videos (required):
![Screen Shot 2021-07-15 at 9 23 21 PM](https://user-images.githubusercontent.com/47767964/125886915-66848214-0c16-4741-9099-5c69190619d9.png)

### Any information needed to test this feature (required):
- Log In as Test User and go to discovery page by clicking link on nav bar

### Any issues with the current functionality (optional):
- first initial push to this, will want to add on to the page based on the team input 
- had some weird issues on trying to map the table headers and the variable column being recognized. Once I could not figure out the issue, I ended up hardcoding the elements instead of mapping. a little frustrating but got the job done. 
- Open to other peoples opinions on what else to add to this page.