### PR TITLE
fixed endpoints to create submission

### DIFF
--- a/client/src/helpers/APICalls/submission.ts
+++ b/client/src/helpers/APICalls/submission.ts
@@ -21,7 +21,7 @@ export const createSubmission = async (images: string[], contestId: string): Pro
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(images),
   };
-  return await fetch(`/contest/${contestId}/submission`, fetchOptions)
+  return await fetch(`/submission/${contestId}`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: { message: 'Unable to connect to server. Please try again' },

--- a/server/routes/contest.js
+++ b/server/routes/contest.js
@@ -3,14 +3,8 @@ const router = express.Router();
 const protect = require('../middleware/auth')
 const { createContest, updateContest, getSingleContest, getAllContests }  = require("../controllers/contest")
 
-const { createSubmission }  = require("../controllers/submission")
-
-
 router.route('/').post(protect,createContest).get(getAllContests)
 
 router.route("/:id").put(protect, updateContest).get(protect, getSingleContest)
-
-//route for creating submission object
-router.route("/:id/submission").post(protect, createSubmission)
 
 module.exports = router;

--- a/server/routes/submission.js
+++ b/server/routes/submission.js
@@ -1,10 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const protect = require('../middleware/auth')
-const { getSubmissionByContest, getSubmissionsByUser }  = require("../controllers/submission")
+const { getSubmissionByContest, getSubmissionsByUser, createSubmission }  = require("../controllers/submission")
 
 router.route('/').get(protect, getSubmissionsByUser)
 
-router.route("/:id").get(protect, getSubmissionByContest)
+router.route("/:id").get(protect, getSubmissionByContest).post(protect, createSubmission)
 
 module.exports = router;


### PR DESCRIPTION
### What this PR does (required):
- This PR is a follow up to my previous branch to refactor the submission controller to combine endpoints. We can now create a submission by sending a POST request to "/submission/:id" which is the same route to GET all submission for that contest.

### Screenshots / Videos (required):
None

### Any information needed to test this feature (required):
- Make a GET request to "/submission/:id" to get all submissions for a contest.
- Make a POST request to "/submission/:id" to create a submission for a contest.

### Any issues with the current functionality (optional):
- No
