### PR TITLE
feature/googleSignUp

### DIFF
--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -170,7 +170,7 @@ exports.googleLogin = asyncHandler(async (req, res, next) => {
             return res.status(400).json({
               error: "Something went wrong..."
             });
-            
+
           } else {
             if (user) {
               const {
@@ -220,8 +220,8 @@ exports.googleLogin = asyncHandler(async (req, res, next) => {
                     return res.status(400).json({
                       error: "Something went wrong..."
                     })
-                  }
-                  console.log("data",data)
+                  };
+                  
                   const {
                     _id,
                     username,


### PR DESCRIPTION
### What this PR does (required):
- If user attempts to sign in with google and have yet to have an account created on Tattoo Art, a record is created and the user can log in with google.

### Screenshots / Videos (required):
- The first record created after a dropped DB

![Screen Shot 2021-07-29 at 7 11 32 PM](https://user-images.githubusercontent.com/47767964/127584878-acb324a0-c892-42ec-a72c-d732579c69a6.png)


### Any information needed to test this feature (required):
-Press sign in with google button and choose google email you would like to sign up with.

### Any issues with the current functionality (optional):
- Pushing this for a review, this works, mostly...when I drop the database and sign up as a new google user everything works perfectly. If I then log out and try to log in/ sign up with a different email, nothing works. 
- I am only able to create one google account, and it is always the first one after I drop the DB. 
- If anyone has any ideas, please let me know. 
