### PR TITLE
linking notifications to contest and messages

### DIFF
--- a/client/src/components/MessageInput/MessageInput.tsx
+++ b/client/src/components/MessageInput/MessageInput.tsx
@@ -23,7 +23,7 @@ const MessageInput = ({ otherUserId, otherUsername }: Props): JSX.Element => {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (loggedInUser && inputRef.current) {
-      const message = await sendMessage({ to: otherUserId, message: inputRef.current.value });
+      const response = await sendMessage({ to: otherUserId, message: inputRef.current.value });
       const notificationBody = { to: otherUserId, notification: `${loggedInUser?.username} sent you a message`};
       const notification = await createNotification(notificationBody);
       //send notification to the socket server using emit action of sendnotification

--- a/client/src/components/NotificationPopUp/NotificationPopUp.tsx
+++ b/client/src/components/NotificationPopUp/NotificationPopUp.tsx
@@ -23,6 +23,14 @@ const GlobalCss = withStyles({
     '*::-webkit-scrollbar': {
       width: '0px',
     },
+    '.badge.MuiSvgIcon-root': {
+      background:'black'
+    },
+    '.MuiBadge-badge.MuiBadge-anchorOriginTopRightRectangle.MuiBadge-colorSecondary ':{
+      fontWeight:'bold',
+      fontSize: '13px',
+      backgroundColor: '#fff',
+    }
   },
 })(() => null);
 
@@ -81,11 +89,11 @@ const NotificationPopUp = (): JSX.Element => {
     <>
       <GlobalCss />
       <Button aria-describedby={id} variant="contained" color="primary" onClick={handleNotification}>
-        <Badge badgeContent={notifications?.length && filterNotification.length}>
-          <Typography className={classes.authHeaderText} color="secondary">
+      <Typography className={classes.authHeaderText} color="secondary">
             Notifications
           </Typography>
-          <NotificationsNoneIcon color="secondary" />
+        <Badge badgeContent={notifications?.length && filterNotification.length} className={classes.badge} color='secondary'>
+          <NotificationsNoneIcon style={{ color:'#fff'}}/>
         </Badge>
       </Button>
       <Popover
@@ -115,9 +123,14 @@ const NotificationPopUp = (): JSX.Element => {
             </Link>
           </Grid>
         </Grid>
-        {notifications?.length
-          ? notifications?.map((notification) => (
-              <Grid direction="row" container key={notification._id}>
+        {notifications?.length ? (
+          notifications?.map((notification) => (
+            <Link
+              to={notification.contestId ? `/contest/${notification.contestId}` : `/dashboard`}
+              key={notification._id}
+              className={classes.link}
+            >
+              <Grid direction="row" container className={classes.notificationContainer}>
                 <Grid item>
                   <Avatar alt="Profile Image" src={notification.profilePic} className={classes.avatar}></Avatar>
                 </Grid>
@@ -130,8 +143,11 @@ const NotificationPopUp = (): JSX.Element => {
                   </Typography>
                 </Grid>
               </Grid>
-            ))
-          : 'No notification'}
+            </Link>
+          ))
+        ) : (
+          <Typography align="center">{`You do not have any notification`}</Typography>
+        )}
       </Popover>
     </>
   );

--- a/client/src/components/NotificationPopUp/useStyles.ts
+++ b/client/src/components/NotificationPopUp/useStyles.ts
@@ -34,6 +34,19 @@ const useStyles = makeStyles((theme) => ({
     top: '15px !important',
     height: '80%',
   },
+  notificationContainer: {
+    '&:hover':{
+      backgroundColor: 'black',
+      color:'#fff'
+    }
+  },
+  link: {
+    textDecoration: "none", 
+    color:'black'
+  },
+  badge:{
+   
+  }
 }));
 
 export default useStyles;

--- a/client/src/context/notificationContext.tsx
+++ b/client/src/context/notificationContext.tsx
@@ -31,7 +31,7 @@ export const NotificationProvider: FunctionComponent = ({ children }): JSX.Eleme
 
   useEffect(() => {
     if (socketNotification) {
-      const updatedNotification = [...notifications, socketNotification];
+      const updatedNotification = notifications.length ? [...notifications, socketNotification] : [socketNotification];
       setNotifications(updatedNotification);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/helpers/APICalls/notification.ts
+++ b/client/src/helpers/APICalls/notification.ts
@@ -60,6 +60,6 @@ export const deleteNotification = async (id: string): Promise<number> => {
   };
 
   return await fetch(`/notification/${id}`, fetchOptions)
-    .then((res) => res.status)
-    .catch((err) => err.status);
+  .then(res => res.status)
+  .catch(err => err);
 };

--- a/client/src/interface/User.ts
+++ b/client/src/interface/User.ts
@@ -52,6 +52,7 @@ export interface Convo {
 }
 
 export interface Message {
+  conversationId: string;
   _id: string;
   senderId: string;
   senderName: string;
@@ -91,6 +92,7 @@ export interface Customer {
 }
 
 export interface Notification {
+  contestId: string;
   opened: boolean;
   _id: string;
   to: string;

--- a/client/src/pages/Notifications/Notifications.tsx
+++ b/client/src/pages/Notifications/Notifications.tsx
@@ -38,7 +38,7 @@ export default function Notifications({ header }: NotificationProps): JSX.Elemen
     } else {
       updateSnackBarMessage('Error deleting notification, trying again later');
     }
-    history.push('/notifications');
+    header === true ? history.push('/notifications') : history.push('/settings');
   };
 
   const hoursCalculator = (createdAt: string): string => {

--- a/client/src/pages/Notifications/Notifications.tsx
+++ b/client/src/pages/Notifications/Notifications.tsx
@@ -12,12 +12,14 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
 import { NotificationContext } from '../../context/notificationContext';
+import { Link, useHistory } from 'react-router-dom';
 
 interface NotificationProps {
   header: boolean;
 }
 
 export default function Notifications({ header }: NotificationProps): JSX.Element {
+  const history = useHistory();
   header === undefined ? (header = true) : header;
   const notifications = useContext(NotificationContext).notifications;
   const setNotifications = useContext(NotificationContext).setNotifications;
@@ -26,6 +28,7 @@ export default function Notifications({ header }: NotificationProps): JSX.Elemen
   const { updateSnackBarMessage } = useSnackBar();
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
     const target = event.target as HTMLButtonElement;
     const response = await deleteNotification(target.value);
     if (response === 204) {
@@ -35,6 +38,7 @@ export default function Notifications({ header }: NotificationProps): JSX.Elemen
     } else {
       updateSnackBarMessage('Error deleting notification, trying again later');
     }
+    history.push('/notifications');
   };
 
   const hoursCalculator = (createdAt: string): string => {
@@ -76,9 +80,14 @@ export default function Notifications({ header }: NotificationProps): JSX.Elemen
               </Typography>
             </Grid>
           </Grid>
-          {notifications?.length
-            ? notifications?.map((notification) => (
-                <Grid direction="row" container key={notification._id}>
+          {notifications?.length ? (
+            notifications?.map((notification) => (
+              <Link
+                to={notification.contestId ? `/contest/${notification.contestId}` : `/dashboard`}
+                key={notification._id}
+                className={classes.link}
+              >
+                <Grid direction="row" container className={classes.notificationContainer}>
                   <Grid item xs={12} sm={3} md={2}>
                     <Avatar alt="Profile Image" src={notification.profilePic} className={classes.avatar}></Avatar>
                   </Grid>
@@ -96,8 +105,11 @@ export default function Notifications({ header }: NotificationProps): JSX.Elemen
                     </button>
                   </Grid>
                 </Grid>
-              ))
-            : 'No notification'}
+              </Link>
+            ))
+          ) : (
+            <Typography align="center">{`You do not have any notification`}</Typography>
+          )}
         </Paper>
       </Box>
     </>

--- a/client/src/pages/Notifications/useStyles.ts
+++ b/client/src/pages/Notifications/useStyles.ts
@@ -54,6 +54,16 @@ const useStyles = makeStyles((theme) => ({
       color: '#fff', 
       backgroundColor:'black',
     }
+  },
+  notificationContainer: {
+    '&:hover':{
+      backgroundColor: '#fafafa',
+      color:'black'
+    }
+  },
+  link: {
+    textDecoration: "none", 
+    color:'black'
   }
 }));
 

--- a/client/src/pages/SubmitDesign/SubmitDesign.tsx
+++ b/client/src/pages/SubmitDesign/SubmitDesign.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent, useContext, useEffect } from 'react';
+import { useState, ChangeEvent } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Paper from '@material-ui/core/Paper';
@@ -61,6 +61,7 @@ export default function SubmitDesign(): JSX.Element {
         const notificationBody = {
           to: toUser.userId,
           notification: `${loggedInUser?.username} submitted in your contest`,
+          contestId: params.id
         };
         const notification = await createNotification(notificationBody);
         //send notification using socket

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -11,6 +11,7 @@ exports.createNotification = asyncHandler(async (req, res) => {
       from: req.user.id,
       notification: body.notification,
       profilePic: user.profilePic,
+      contestId: body.contestId
     });
 
     res.status(201).json(notification);
@@ -48,6 +49,7 @@ exports.updateNotification = asyncHandler(async (req, res) => {
     to: body.to,
     from: body.from,
     notification: body.notification,
+    contestId: body.contestId
   };
 
   try {

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -22,6 +22,9 @@ const notificationSchema = new mongoose.Schema(
     },
     profilePic: {
       type: String
+    },
+    contestId:{
+      type: String
     }
   },
   {


### PR DESCRIPTION
### What this PR does (required):
- This PR contains feature, which links to particular contests and message dashboard when notifications are clicked
- Added property contestId in the notification model , in order to achieve this feature
- Added some styling for notifications on-hover and also for notification badge

### Screenshots / Videos (required):
<img width="1265" alt="Screen Shot 2021-08-05 at 17 26 37" src="https://user-images.githubusercontent.com/84412422/128424212-f0e167b1-4fbd-4fe8-a8b8-f036484bd51f.png">
<img width="1237" alt="Screen Shot 2021-08-05 at 17 33 05" src="https://user-images.githubusercontent.com/84412422/128424222-f45d4d12-4ef8-4e04-a3e8-c336278f434b.png">


### Any information needed to test this feature (required):
- Go to notification box, to see your notifications. Simply click on any notification.

### Any issues with the current functionality (optional):
- List any problems where you were not able to complete all tasks on ticket
- List any problems this PR may cause for the project or other active PRs
- Post a screenshot/video of the problem, along with detailed console outputs where applicable
